### PR TITLE
Further compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,17 @@ The "Status" and "Identifier" fields are used to track the processing state of i
 
 5. Monitor the progress in the output area of the GUI.
 
+## Other language
+
+To make Image Indexer fully compatible with other languages (French for instance) follow these steps:
+
+1. Into Image Indexer GUI, go to Settings then "Edit Instructions":
+   - Into the prompt, replace "Use ENGLISH only" by "Use FRENCH only"
+
+2. Into Keyword Corrections:
+   - Uncheck "Depluralize keywords"
+   - Uncheck "Only Latin characters"
+
 ## Settings
 
    **Press the HELP button in the settings dialog.**

--- a/src/llmii.py
+++ b/src/llmii.py
@@ -528,7 +528,7 @@ class FileProcessor:
         
         self.image_processor = ImageProcessor(max_dimension=self.config.res_limit, patch_sizes=[14])
         
-        self.et = exiftool.ExifToolHelper(check_execute=False)
+        self.et = exiftool.ExifToolHelper(encoding='utf-8')
         
         # Words in the prompt tend to get repeated back by certain models
         self.banned_words = ["no", "unspecified", "unknown", "standard", "unidentified", "time", "category", "actions", "setting", "objects", "visual", "elements", "activities", "appearance", "professions", "relationships", "identify", "photography", "photographic", "topiary"]


### PR DESCRIPTION
1. Now **Image Indexer can be multilingual**.

___

2. If the folder contains an empty file, the the whole process stops without tagging any picture at all.
With this fix, **Image Indexer can skip any empty file so that the process can work anyway on every other files.**

> Among my 90 000+ pictures, 3 were actually empty (0.00kb jpg). Here is an example of [two empty files](https://github.com/user-attachments/files/19622300/TwoEmptyFiles.zip).

